### PR TITLE
docs(readme): Gitflow 브랜치 명명 규칙 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,41 @@ git log --branches --decorate --graph 브렌치 상황 보기
 git log --branches --decorate --graph --oneline 간결하게 브렌치 상황 보기
 
 
-! README파일은 MAIN브렌치에서 커밋
-! 그 외는 그 외 브렌치에서 처리
+## master 브랜치:
 
+목적: 항상 배포 가능한 상태의 최종 제품 코드를 유지합니다. 실제로 프로덕션에 배포되는 안정적인 코드만 포함됩니다.
 
-hotfix_ 실서버에서 문제가 생겼을 때 급하게 작업하기 위한 브랜치
-feature_ 이슈 수정 및 추가 개발에 사용되며 실제로는 푸쉬하지 않을 브랜치
-release_ 실서버에 푸쉬하면서 최종적으로 이슈를 해결할 브랜치
-branch 이름
-Exp_ 기능개발
-Iss_  이슈
+예시 이름: master
+## develop 브랜치:
+
+목적: 현재 개발 중인 기능들을 통합하는 브랜치입니다. 모든 새로운 기능과 변경 사항은 이 브랜치에서 테스트되고 통합됩니다.
+
+예시 이름: develop
+## feature 브랜치:
+
+목적: 새로운 기능이나 특정 작업을 구현하기 위한 브랜치입니다. develop 브랜치에서 파생되며, 완료되면 develop으로 병합됩니다.
+
+이름 형식: feature/{기능명}
+
+예시 이름: feature/auth-login, feature/user-profile-update
+## release 브랜치:
+
+목적: 배포를 준비하는 브랜치로, 버그 수정 및 최종 테스트를 진행하는 곳입니다. 이 브랜치에서 완료된 코드는 master와 develop 브랜치에 병합됩니다.
+
+이름 형식: release/{버전번호}
+
+예시 이름: release/1.0.0, release/2.1.0
+## hotfix 브랜치:
+
+목적: 프로덕션에서 발견된 중요한 버그를 즉시 수정하는 브랜치입니다. master 브랜치에서 파생되며, 완료 후 master와 develop에 모두 병합됩니다.
+
+이름 형식: hotfix/{버그명} 또는 hotfix/{버전번호}
+
+예시 이름: hotfix/login-crash, hotfix/1.0.1
+## support 브랜치 (선택적):
+
+목적: 이전 버전의 유지보수와 지원을 위해 사용될 수 있습니다. 일반적으로 긴급한 수정이 필요할 때 사용합니다.
+
+이름 형식: support/{버전번호}
+
+예시 이름: support/1.x


### PR DESCRIPTION
Gitflow 브랜치 유형에 대한 상세 설명을 추가했습니다:
- master: 프로덕션 준비 완료된 코드
- develop: 개발 중인 기능들의 통합 브랜치
- feature: 새로운 기능을 구현하기 위한 브랜치
- release: 배포 준비를 위한 브랜치
- hotfix: 긴급한 프로덕션 버그 수정을 위한 브랜치
- support: 이전 버전 지원을 위한 브랜치

각 Gitflow 브랜치의 명명과 목적에 대한 명확한 지침을 제공합니다.